### PR TITLE
Update values for cert-manager

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -296,6 +296,8 @@
   repository: https://charts.jetstack.io
   valuesFile: |
     installCRDs: true
+    crds:
+      enabled: true
 - entries:
     - trust-manager
   kind: helm


### PR DESCRIPTION
CRDs installation is possibly triggered by a different values settings per version 1.15.0.

See https://github.com/cert-manager/cert-manager/pull/6760