### PR TITLE
Allow values files to be version-aware

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -294,10 +294,14 @@
   kind: helm
   name: cert-manager
   repository: https://charts.jetstack.io
-  valuesFile: |
-    installCRDs: true
-    crds:
-      enabled: true
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        installCRDs: true
+    - version: 1.15.0
+      valuesFile: |
+        crds:
+          enabled: true
 - entries:
     - trust-manager
   kind: helm
@@ -459,21 +463,23 @@
   kind: helm
   name: grafana
   repository: https://grafana.github.io/helm-charts
-  valuesFile: |
-    cluster:
-      name: my-cluster
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        cluster:
+          name: my-cluster
 
-    externalServices:
-      prometheus:
-        host: https://prometheus.example.com
-        basicAuth:
-          username: "12345"
-          password: "It's a secret to everyone"
-      loki:
-        host: https://loki.example.com
-        basicAuth:
-          username: "67890"
-          password: "It's a secret to everyone"
+        externalServices:
+          prometheus:
+            host: https://prometheus.example.com
+            basicAuth:
+              username: "12345"
+              password: "It's a secret to everyone"
+          loki:
+            host: https://loki.example.com
+            basicAuth:
+              username: "67890"
+              password: "It's a secret to everyone"
 - entries:
     - vault-secrets-operator
   kind: helm
@@ -805,10 +811,12 @@
   kind: helm
   name: opentelemetry-helm
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  valuesFile: |
-    manager:
-      collectorImage:
-        repository: otel/opentelemetry-collector-k8s
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        manager:
+          collectorImage:
+            repository: otel/opentelemetry-collector-k8s
 - kind: git
   name: operator-framework-api
   repository: https://github.com/operator-framework/api
@@ -877,11 +885,13 @@
   kind: helm
   name: teleport-agent-kube
   repository: https://charts.releases.teleport.dev
-  valuesFile: |
-    chartMode: standalone
-    clusterName: teleport.example.com
-    teleportAddress: teleport.example.com:443
-    teleportClusterName: teleport
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        chartMode: standalone
+        clusterName: teleport.example.com
+        teleportAddress: teleport.example.com:443
+        teleportClusterName: teleport
 - entries:
     - temporal-operator
   kind: helm
@@ -897,14 +907,16 @@
   kind: helm-oci
   name: tinkerbell
   repository: oci://ghcr.io/tinkerbell/charts/stack
-  valuesFile: |
-    smee:
-      publicIP: 127.0.0.1
-      trustedProxies: localhost
-    hegel:
-      trustedProxies: localhost
-    stack:
-      loadBalancerIP: 127.0.0.1
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        smee:
+          publicIP: 127.0.0.1
+          trustedProxies: localhost
+        hegel:
+          trustedProxies: localhost
+        stack:
+          loadBalancerIP: 127.0.0.1
 - entries:
     - traefik
   kind: helm

--- a/src/00-utilities.sh
+++ b/src/00-utilities.sh
@@ -1,0 +1,21 @@
+values_file_of() {
+    local input=$1
+    local repository=$2
+    local name=$3
+    local version=$4
+    local relevant_version
+
+    if [ "" = "$4" ]; then
+        version=$(yq -o json $input | jq -rc --arg repository $repository --arg name $name '.[] | select(.repository == $repository and .name == $name) | .valuesFiles // [] | map(. as $item | ($item.version | split(".")) as $version | {major: $version[0], minor: $version[1], patch: $version[2], version: $item.version} ) | sort_by(.major, .minor, .patch) | last | .version // "0.0.0"')
+    fi
+
+    keys=$(yq -o json $input | jq -rc --arg repository $repository --arg name $name '.[] | select(.repository == $repository and .name == $name) | .valuesFiles // [] | .[].version // "0.0.0"')
+
+    if echo "$keys" | grep "$version" >/dev/null; then
+        relevant_version=$version
+    else
+        relevant_version=$({ echo $version; echo $keys; } | tr ' ' "\n" | sort -t "." -k1,1n -k2,2n -k3,3n | grep -B1 $version | grep -v $version)
+    fi
+
+    yq -o json $input | jq -rcj --arg repository $repository --arg name $name --arg version $relevant_version '.[] | select(.repository == $repository and .name == $name) | .valuesFiles // [] | .[] | select(.version == $version) | .valuesFile // ""'
+}

--- a/src/22-oci-template.sh
+++ b/src/22-oci-template.sh
@@ -11,7 +11,7 @@ for repository in ${repositories}; do
 
     printf '  - %s\n' "$repository"
 
-    yq -o json $input | jq -rc --arg repository $repository '.[] | select(.repository == $repository) | .valuesFile // ""' > /tmp/values
+    values_file_of "$input" "$repository" "$name" > /tmp/values
 
     mkdir -p "$(printf "$output" "$name" "$entry" | tr '[:upper:]' '[:lower:]')" || true
     version=$(helm template "$repository" -f /tmp/values 2>&1 | head -n1 | cut -d: -f3)
@@ -33,6 +33,7 @@ for repository in ${repositories}; do
 
     for version in ${versions}; do
         printf '      - version %s\n' "$version"
+        values_file_of "$input" "$repository" "$name" "$version" > /tmp/values
         file=$(printf "$outputfile" "$name" "$entry" "$version" | tr '[:upper:]' '[:lower:]')
         helm template --include-crds "$repository" --version "$version" -f /tmp/values 2>/dev/null | yq 'select(.kind == "CustomResourceDefinition")' > "$file"
     done

--- a/test/configuration.yaml
+++ b/test/configuration.yaml
@@ -30,5 +30,9 @@
   kind: helm
   name: templated-chart
   repository: http://localhost:8000
-  valuesFile: |
-    output: true
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        output: true
+    - version: 2.0.0
+      valuesFile: |

--- a/test/fixtures/values-files.yaml
+++ b/test/fixtures/values-files.yaml
@@ -1,0 +1,19 @@
+- entries:
+    - templated
+  kind: helm
+  name: versioned
+  repository: repository
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        output: true
+    - version: 2.0.0
+      valuesFile: |
+    - version: 1.0.0
+      valuesFile: |
+        output: true
+- entries:
+    - regular
+  kind: helm
+  name: unversioned
+  repository: repository

--- a/test/prepare-20-charts.sh
+++ b/test/prepare-20-charts.sh
@@ -34,6 +34,14 @@ yq -i '.spec.group = "chart.local"' /tmp/charts/regular/2.0/crds/crd.yaml
 
 cp -r /tmp/charts/base/templated /tmp/charts/templated/1.0
 yq -i '.version = "1.0.0"' /tmp/charts/templated/1.0/Chart.yaml
+cp -r /tmp/charts/base/templated /tmp/charts/templated/2.0
+yq -i '.version = "2.0.0"' /tmp/charts/templated/2.0/Chart.yaml
+{
+    echo '{{- if .Values.output }}'
+    echo '{{- fail "value for .Values.output is not allowed in this version" }}'
+    echo '{{- end }}'
+    yq '.spec.group = "chart.unconditional"' < /app/test/fixtures/test-crd.yaml
+} > /tmp/charts/templated/2.0/templates/crd.yaml
 
 cd /repository/http/
 
@@ -42,6 +50,7 @@ helm package /tmp/charts/regular/1.5
 helm package /tmp/charts/regular/2.0
 
 helm package /tmp/charts/templated/1.0
+helm package /tmp/charts/templated/2.0
 
 helm repo index .
 

--- a/test/prepare-30-verified-schemas.sh
+++ b/test/prepare-30-verified-schemas.sh
@@ -8,13 +8,14 @@ cp /app/test/fixtures/*.json /tmp/verified/base/
 
 if [ "$1" = "all-versions" ]; then
     cp -r /tmp/verified/base /verified-schema/chart.conditional
+    cp -r /tmp/verified/base /verified-schema/chart.unconditional
     cp -r /tmp/verified/base /verified-schema/chart.git
     cp -r /tmp/verified/base /verified-schema/chart.old
     cp -r /tmp/verified/base /verified-schema/chart.local
     cp -r /tmp/verified/base /verified-schema/chart.uri
     cp -r /tmp/verified/base /verified-schema/chart.uri1
 elif [ "$1" = "only-latest" ]; then
-    cp -r /tmp/verified/base /verified-schema/chart.conditional
+    cp -r /tmp/verified/base /verified-schema/chart.unconditional
     cp -r /tmp/verified/base /verified-schema/chart.git
     cp -r /tmp/verified/base /verified-schema/chart.local
     cp -r /tmp/verified/base /verified-schema/chart.uri

--- a/test/prepare-40-known-schemas.sh
+++ b/test/prepare-40-known-schemas.sh
@@ -4,6 +4,7 @@ if [ "$1" = "only-latest" ]; then
     mkdir -p /schema/chart.local/ &>/dev/null || true
     mkdir -p /schema/chart.new/ &>/dev/null || true
     mkdir -p /schema/chart.uri/ &>/dev/null || true
+    mkdir -p /schema/chart.unconditional/ &>/dev/null || true
 fi
 
 echo "  - updated for test '$1'"

--- a/test/unit-test-values-files.sh
+++ b/test/unit-test-values-files.sh
@@ -1,0 +1,62 @@
+set -e
+
+printf '- entries:
+    - templated
+  kind: helm
+  name: versioned
+  repository: repository
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        output: true
+    - version: 2.0.0
+      valuesFile: |
+    - version: 1.0.0
+      valuesFile: |
+        output: true
+- entries:
+    - regular
+  kind: helm
+  name: unversioned
+  repository: repository
+' > /tmp/input
+
+echo 'output: true' > /tmp/expected
+values_file_of /tmp/input repository versioned 0.0.0 > /tmp/output
+diff /tmp/expected /tmp/output
+
+echo 'output: true' > /tmp/expected
+values_file_of /tmp/input repository versioned 1.0.0 > /tmp/output
+diff /tmp/expected /tmp/output
+
+echo 'output: true' > /tmp/expected
+values_file_of /tmp/input repository versioned 1.999.999 > /tmp/output
+diff /tmp/expected /tmp/output
+
+printf '' > /tmp/expected
+values_file_of /tmp/input repository versioned 2.0.0 > /tmp/output
+diff /tmp/expected /tmp/output
+
+printf '' > /tmp/expected
+values_file_of /tmp/input repository versioned 2.999.999 > /tmp/output
+diff /tmp/expected /tmp/output
+
+printf '' > /tmp/expected
+values_file_of /tmp/input repository versioned > /tmp/output
+diff /tmp/expected /tmp/output
+
+printf '' > /tmp/expected
+values_file_of /tmp/input repository unversioned 0.0.0 > /tmp/output
+diff /tmp/expected /tmp/output
+
+printf '' > /tmp/expected
+values_file_of /tmp/input repository unversioned 1.0.0 > /tmp/output
+diff /tmp/expected /tmp/output
+
+printf '' > /tmp/expected
+values_file_of /tmp/input repository unversioned 2.0.0 > /tmp/output
+diff /tmp/expected /tmp/output
+
+printf '' > /tmp/expected
+values_file_of /tmp/input repository unversioned > /tmp/output
+diff /tmp/expected /tmp/output

--- a/test/unit-test-values-files.sh
+++ b/test/unit-test-values-files.sh
@@ -1,62 +1,41 @@
 set -e
 
-printf '- entries:
-    - templated
-  kind: helm
-  name: versioned
-  repository: repository
-  valuesFiles:
-    - version: 0.0.0
-      valuesFile: |
-        output: true
-    - version: 2.0.0
-      valuesFile: |
-    - version: 1.0.0
-      valuesFile: |
-        output: true
-- entries:
-    - regular
-  kind: helm
-  name: unversioned
-  repository: repository
-' > /tmp/input
-
 echo 'output: true' > /tmp/expected
-values_file_of /tmp/input repository versioned 0.0.0 > /tmp/output
+values_file_of test/fixtures/values-files.yaml repository versioned 0.0.0 > /tmp/output
 diff /tmp/expected /tmp/output
 
 echo 'output: true' > /tmp/expected
-values_file_of /tmp/input repository versioned 1.0.0 > /tmp/output
+values_file_of test/fixtures/values-files.yaml repository versioned 1.0.0 > /tmp/output
 diff /tmp/expected /tmp/output
 
 echo 'output: true' > /tmp/expected
-values_file_of /tmp/input repository versioned 1.999.999 > /tmp/output
+values_file_of test/fixtures/values-files.yaml repository versioned 1.999.999 > /tmp/output
 diff /tmp/expected /tmp/output
 
 printf '' > /tmp/expected
-values_file_of /tmp/input repository versioned 2.0.0 > /tmp/output
+values_file_of test/fixtures/values-files.yaml repository versioned 2.0.0 > /tmp/output
 diff /tmp/expected /tmp/output
 
 printf '' > /tmp/expected
-values_file_of /tmp/input repository versioned 2.999.999 > /tmp/output
+values_file_of test/fixtures/values-files.yaml repository versioned 2.999.999 > /tmp/output
 diff /tmp/expected /tmp/output
 
 printf '' > /tmp/expected
-values_file_of /tmp/input repository versioned > /tmp/output
+values_file_of test/fixtures/values-files.yaml repository versioned > /tmp/output
 diff /tmp/expected /tmp/output
 
 printf '' > /tmp/expected
-values_file_of /tmp/input repository unversioned 0.0.0 > /tmp/output
+values_file_of test/fixtures/values-files.yaml repository unversioned 0.0.0 > /tmp/output
 diff /tmp/expected /tmp/output
 
 printf '' > /tmp/expected
-values_file_of /tmp/input repository unversioned 1.0.0 > /tmp/output
+values_file_of test/fixtures/values-files.yaml repository unversioned 1.0.0 > /tmp/output
 diff /tmp/expected /tmp/output
 
 printf '' > /tmp/expected
-values_file_of /tmp/input repository unversioned 2.0.0 > /tmp/output
+values_file_of test/fixtures/values-files.yaml repository unversioned 2.0.0 > /tmp/output
 diff /tmp/expected /tmp/output
 
 printf '' > /tmp/expected
-values_file_of /tmp/input repository unversioned > /tmp/output
+values_file_of test/fixtures/values-files.yaml repository unversioned > /tmp/output
 diff /tmp/expected /tmp/output


### PR DESCRIPTION
cert-manager requires certain values in the values file to output the CRDs. The recent change of which values are required and the requirement of the old values no longer being present have added a need for the values file definition be aware of which version they belong to.