### PR TITLE
fix: Fixed oci based shell script

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -799,15 +799,6 @@
     - version: 0.0.0
       valuesFile: |
         createCustomResource: true
-    - version: 4.10.0
-      valuesFile: |
-        createCustomResource: true
-    - version: 4.9.1
-      valuesFile: |
-        createCustomResource: true
-    - version: 4.8.0
-      valuesFile: |
-        createCustomResource: true
 - entries:
     - metallb
   kind: helm

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -795,6 +795,19 @@
   kind: helm-oci
   name: logging-operator
   repository: oci://ghcr.io/kube-logging/helm-charts/logging-operator
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        createCustomResource: true
+    - version: 4.10.0
+      valuesFile: |
+        createCustomResource: true
+    - version: 4.9.1
+      valuesFile: |
+        createCustomResource: true
+    - version: 4.8.0
+      valuesFile: |
+        createCustomResource: true
 - entries:
     - metallb
   kind: helm

--- a/src/22-oci-template.sh
+++ b/src/22-oci-template.sh
@@ -6,8 +6,8 @@ echo "Templating (oci) ..."
 for repository in ${repositories}; do
     versions=$(yq -o json $input | jq -rc --arg repository $repository '.[] | select(.repository == $repository) | .additionalVersions[]')
     combinedname=$(echo "$repository" | rev | cut -d/ -f1-2 | rev)
-    name=$(echo "$combinedname" | cut -d/ -f1)
-    entry=$(echo "$combinedname" | cut -d/ -f2)
+    name=$(echo "$combinedname" | cut -d/ -f2)
+    entry=$(echo "$combinedname" | cut -d/ -f1)
 
     printf '  - %s\n' "$repository"
 


### PR DESCRIPTION
Somehow the name/entry cut in the shell script was not parsing correctly the config.
I've rerun several times locally the script deleting schemas for other OCI based chart and looked like it works.
I don't know if I should remove the scheduled commits or not.

I hape this PR is okay.