### PR TITLE
feat: Add helm-oci test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,11 @@ jobs:
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@v4
       - run: make ci-test

--- a/Makefile
+++ b/Makefile
@@ -101,4 +101,5 @@ shell-command: build-shell
 	-v $$(pwd)/test/fixtures:/app/test/fixtures:ro \
 	-v $$(pwd):/workspace \
 	-w /workspace \
+	--network host \
 	crd-runner /bin/sh -c 'make $(CI_COMMAND)'

--- a/test/configuration.yaml
+++ b/test/configuration.yaml
@@ -36,3 +36,21 @@
         output: true
     - version: 2.0.0
       valuesFile: |
+- additionalVersions:
+    - 1.5.0
+    - 1.0.0
+  kind: helm-oci
+  name: regular-oci
+  repository: oci://localhost:5000/myorg/myrepo/regular
+- additionalVersions:
+    - 1.0.0
+  kind: helm-oci
+  name: templated-oci
+  repository: oci://localhost:5000/myorg/myrepo/templated
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        output: true
+    - version: 2.0.0
+      valuesFile: |
+        output: true

--- a/test/prepare-20-charts.sh
+++ b/test/prepare-20-charts.sh
@@ -46,11 +46,16 @@ yq -i '.version = "2.0.0"' /tmp/charts/templated/2.0/Chart.yaml
 cd /repository/http/
 
 helm package /tmp/charts/regular/1.0
+helm push regular-1.0.0.tgz oci://localhost:5000/myorg/myrepo
 helm package /tmp/charts/regular/1.5
+helm push regular-1.5.0.tgz oci://localhost:5000/myorg/myrepo
 helm package /tmp/charts/regular/2.0
+helm push regular-2.0.0.tgz oci://localhost:5000/myorg/myrepo
 
 helm package /tmp/charts/templated/1.0
+helm push templated-1.0.0.tgz oci://localhost:5000/myorg/myrepo
 helm package /tmp/charts/templated/2.0
+helm push templated-2.0.0.tgz oci://localhost:5000/myorg/myrepo
 
 helm repo index .
 


### PR DESCRIPTION
This needs additional service container for test action
Unfortunatly based on this [discussion](https://github.com/docker/build-push-action/discussions/1020) host network is needed
It could be queried out from docker network ls, but I'm not familiar enough with Makefile