### PR TITLE
Handle multiple sources generating same outputs

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -525,6 +525,13 @@
   kind: helm
   name: elastic
   repository: https://helm.elastic.co
+- kind: helm-oci
+  name: emissary-ingress
+  repository: oci://ghcr.io/emissary-ingress/emissary-crds-chart
+  valuesFiles:
+    - version: 0.0.0
+      valuesFile: |
+        enableLegacyVersions: true
 - entries:
     - emqx-operator
   kind: helm
@@ -583,6 +590,12 @@
     - config/crd
   versionPrefix: v
 - kind: git
+  name: fluxcd-helm-operator
+  repository: https://github.com/fluxcd/helm-operator
+  searchPaths:
+    - deploy
+  versionPrefix: v
+- kind: git
   name: fluxcd-image-automation-controller
   repository: https://github.com/fluxcd/image-automation-controller
   searchPaths:
@@ -590,7 +603,7 @@
   versionPrefix: v
 - kind: git
   name: fluxcd-image-reflector-controller
-  repository: https://github.com/image-reflector-controller
+  repository: https://github.com/fluxcd/image-reflector-controller
   searchPaths:
     - config/crd
   versionPrefix: v
@@ -682,6 +695,9 @@
             basicAuth:
               username: "67890"
               password: "It's a secret to everyone"
+- kind: helm-oci
+  name: grafana-operator
+  repository: oci://ghcr.io/grafana/helm-charts/grafana-operator
 - entries:
     - hcp-terraform-operator
     - vault-secrets-operator
@@ -782,6 +798,13 @@
   searchPaths:
     - vertical-pod-autoscaler/deploy
   versionPrefix: vertical-pod-autoscaler-
+- kind: git
+  name: kubernetes-csi-external-snapshotter
+  repository: https://github.com/kubernetes-csi/external-snapshotter
+  searchPaths:
+    - config/crd
+    - client/config/crd
+  versionPrefix: v
 - kind: git
   name: kubernetes-ingress-gce
   repository: https://github.com/kubernetes/ingress-gce

--- a/internal/command/updater_test.go
+++ b/internal/command/updater_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRun(t *testing.T) {
-	configTmpl := `
+	template := `
 - apiGroups:
     - chart.uri
   crds:
@@ -37,7 +37,7 @@ func TestRun(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	config := path.Join(tmpDir, "config.yaml")
-	os.WriteFile(config, []byte(strings.ReplaceAll(configTmpl, "{{ server }}", server.URL)), 0664)
+	os.WriteFile(config, []byte(strings.ReplaceAll(template, "{{ server }}", server.URL)), 0664)
 
 	updater := NewUpdater(config, tmpDir, bytes.NewBuffer([]byte{}), nil)
 


### PR DESCRIPTION
If multiple sources generates the same `group/kind_version.json`, then it is important to not generate directly into the schema repository. This is to allow sources - in any ordering - to recognize that they should each regenerate using all of their version history.

Also more sources are updated/added.