### PR TITLE
fix: clean out generators source files correctly

### DIFF
--- a/internal/generator/factory.go
+++ b/internal/generator/factory.go
@@ -65,6 +65,8 @@ func NewBuilder(config configuration.Configuration, reader crd.CrdReader, genera
 }
 
 func (builder Builder) Build() error {
+	defer builder.generator.Close()
+
 	logger := builder.logger
 
 	fmt.Fprintf(logger, "Producing for %s@%s:\n", builder.config.Name, builder.config.Kind)
@@ -143,8 +145,6 @@ func (builder Builder) Build() error {
 			}
 		}
 	}
-
-	builder.generator.Close()
 
 	return nil
 }

--- a/internal/generator/git.go
+++ b/internal/generator/git.go
@@ -33,7 +33,7 @@ func NewGitGenerator(config configuration.Configuration, reader crd.CrdReader) G
 }
 
 func (generator *GitGenerator) Close() error {
-	return os.Remove(generator.tmpDir)
+	return os.RemoveAll(generator.tmpDir)
 }
 
 func (generator *GitGenerator) MetaData(version string) ([]crd.CrdMetaSchema, error) {

--- a/internal/generator/helm.go
+++ b/internal/generator/helm.go
@@ -112,7 +112,7 @@ func (generator *HelmGenerator) Versions() ([]string, error) {
 }
 
 func (generator *HelmGenerator) Close() error {
-	return os.Remove(generator.tmpDir)
+	return os.RemoveAll(generator.tmpDir)
 }
 
 func (generator *HelmGenerator) ensureLoaded() error {

--- a/internal/generator/oci.go
+++ b/internal/generator/oci.go
@@ -41,7 +41,7 @@ func NewOciGenerator(config configuration.Configuration, reader crd.CrdReader) G
 }
 
 func (generator *OciGenerator) Close() error {
-	return os.Remove(generator.tmpDir)
+	return os.RemoveAll(generator.tmpDir)
 }
 
 func (generator *OciGenerator) MetaData(version string) ([]crd.CrdMetaSchema, error) {

--- a/make.d/build.mk
+++ b/make.d/build.mk
@@ -1,4 +1,5 @@
 export RUNNER=ghcr.io/customresourcedefinition/catalog-runner:$(shell docker run -v $$(pwd)/Dockerfile:/Dockerfile --rm alpine /bin/sh -c 'md5sum < /Dockerfile | cut -f1 -d" "' 2>/dev/null)
+PLATFORM := $(shell docker version --format '{{.Server.Os}}/{{.Server.Arch}}')
 
 # tags are also required in .vscode/settings.json
 GO_TAGS = containers_image_openpgp
@@ -12,10 +13,13 @@ ifeq ($(strip $(GITHUB_REF)),refs/heads/main)
 	test -n "$$(docker images -q $(RUNNER))" || \
 		docker pull $(RUNNER) || \
 		docker build --tag $(RUNNER) --push .
-else
+else ifneq ($(strip $(CI)),)
 	test -n "$$(docker images -q $(RUNNER))" || \
 		docker pull $(RUNNER) || \
 		docker build --tag $(RUNNER) .
+else
+	test -n "$$(docker images -q $(RUNNER))" || \
+		docker build --platform=$(PLATFORM) --tag $(RUNNER) .
 endif
 
 	test -n "$$(docker images -q $(RUNNER))"


### PR DESCRIPTION
This commit also tweaks how an image is created for local development to ensure platform is respected.