### PR TITLE
fix: avoid apply additional properties too much

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,8 +1,15 @@
 {
-  "ignorePaths": ["go.mod", "go.sum"],
+  "ignorePaths": [
+    "go.mod",
+    "go.sum"
+  ],
   "language": "en",
   "version": "0.2",
   "words": [
+    "apiextensions",
+    "apimachinery",
+    "apiserver",
+    "APIV",
     "buildvcs",
     "chartutil",
     "checkmake",

--- a/internal/command/updater_test.go
+++ b/internal/command/updater_test.go
@@ -184,7 +184,7 @@ func assertDirectories(t *testing.T, a, b string) {
 // Test is skipped during unit testing and meant for step-debugging a local check
 func TestCheckLocal(t *testing.T) {
 	output := "../../build/ephemeral/schema"
-	config := "../../test/configuration.yaml"
+	config := "../../build/configuration.yaml"
 	updater := NewUpdater(config, output, output, nil, nil)
 
 	err := updater.Run()

--- a/internal/crd/crd.go
+++ b/internal/crd/crd.go
@@ -196,7 +196,7 @@ func (s *CrdMetaSchema) Filepath() string {
 }
 
 func applyDefaults(schema *v1.JSONSchemaProps, skip bool) {
-	if !skip && len(schema.Properties) > 0 && schema.AdditionalProperties == nil {
+	if !skip && schema.Type == "object" && len(schema.Properties) > 0 && schema.AdditionalProperties == nil {
 		schema.AdditionalProperties = &v1.JSONSchemaPropsOrBool{Allows: false}
 	}
 


### PR DESCRIPTION
This fix for #142 requires regenerating every version of everything in the catalog to actually fix older schema versions that no longer are part of their latest release.